### PR TITLE
add get_optional_bearer_token dependency for main app

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -7,7 +7,7 @@ from contextlib import asynccontextmanager
 
 from app.settings import settings
 from app.utils.helpers import TAGS_METADATA
-from app.utils.dependencies import verify_api_key, get_db_session, verify_clerk_token, SessionDep
+from app.utils.dependencies import verify_api_key, get_db_session, get_optional_bearer_token, SessionDep
 from app.utils.logging_config import setup_logging
 from app.utils.exception_handlers import register_exception_handlers
 from app.db.database import connect_db, close_db
@@ -44,7 +44,7 @@ app = FastAPI(
     version="1.0.0",
     openapi_tags=TAGS_METADATA,
     lifespan=lifespan, 
-    dependencies=[Depends(verify_api_key), Depends(verify_clerk_token), Depends(get_db_session)],
+    dependencies=[Depends(verify_api_key), Depends(get_optional_bearer_token), Depends(get_db_session)],
     swagger_ui_parameters={"persistAuthorization": True}
 )
 

--- a/app/utils/dependencies.py
+++ b/app/utils/dependencies.py
@@ -28,7 +28,13 @@ def verify_api_key(api_key: str | None = Depends(api_key_header)) -> None:
             detail="Unauthorized: Invalid or missing API Key"
         )
 
-def verify_clerk_token(bearer_token: HTTPAuthorizationCredentials | None = Depends(bearer_token_header)) -> dict:
+def get_optional_bearer_token(bearer_token: HTTPAuthorizationCredentials | None = Depends(bearer_token_header)) -> HTTPAuthorizationCredentials | None:
+    """
+    Dependency to get optional bearer token from bearer token header. Returns the bearer token if it is present, otherwise returns None.
+    """
+    return bearer_token
+
+def verify_clerk_token(bearer_token: HTTPAuthorizationCredentials | None = Depends(get_optional_bearer_token)) -> dict:
     """
     Dependency to verify Clerk token from bearer token header.
     

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,7 @@ from app.main import app
 from app.utils.dependencies import (
     get_db_session,
     require_admin,
+    get_optional_bearer_token,
     verify_clerk_token
 )
 from app.settings import settings
@@ -43,6 +44,7 @@ def disable_app_lifespan():
 @pytest.fixture(scope="session", autouse=True)
 def bypass_auth():
     """Bypass authentication for testing"""
+    app.dependency_overrides[get_optional_bearer_token] = lambda: None
     app.dependency_overrides[verify_clerk_token] = lambda: {
         "sub": "test_user",
         "public_metadata": {"role": "admin"}


### PR DESCRIPTION
Set optional bearer token on main FastAPI app so tokens sent for read routes are not blocked by irrelevant errors. Pass the result to the existing verify clerk token dependency for write routes.