### PR TITLE
Fix OPTIONS method issues

### DIFF
--- a/app/api/event_assignments.py
+++ b/app/api/event_assignments.py
@@ -1,10 +1,13 @@
 from fastapi import APIRouter, Depends
 
 from app.db.models import EventAssignmentUpdate, EventAssignmentPublic
-from app.utils.dependencies import SessionDep, EventWithFullHierarchyForAssignmentsDep, EventAssignmentDep, require_admin
+from app.utils.dependencies import SessionDep, EventWithFullHierarchyForAssignmentsDep, EventAssignmentDep, require_admin, verify_api_key, get_optional_bearer_token, get_db_session
 from app.services.domain import get_event_assignments_from_event, update_event_assignment
 
-router = APIRouter(tags=["event_assignments"])
+router = APIRouter(
+    tags=["event_assignments"], 
+    dependencies=[Depends(verify_api_key), Depends(get_optional_bearer_token), Depends(get_db_session)]
+)
 
 # Event Assignments are inserted when a new event is created - no direct route
 # Event Assignments are cascade deleted when the event is deleted - no direct route

--- a/app/api/event_types.py
+++ b/app/api/event_types.py
@@ -2,10 +2,14 @@ from fastapi import APIRouter, status, Response, Depends
 from sqlmodel import select
 
 from app.db.models import EventType, EventTypeCreate, EventTypeUpdate
-from app.utils.dependencies import SessionDep, EventTypeDep, require_admin
+from app.utils.dependencies import SessionDep, EventTypeDep, require_admin, verify_api_key, get_optional_bearer_token, get_db_session
 from app.services.domain import create_object, update_object, delete_object
 
-router = APIRouter(prefix="/event_types", tags=["event_types"])
+router = APIRouter(
+    prefix="/event_types", 
+    tags=["event_types"], 
+    dependencies=[Depends(verify_api_key), Depends(get_optional_bearer_token), Depends(get_db_session)]
+)
 
 @router.get("", response_model=list[EventType])
 def get_all_event_types(session: SessionDep):

--- a/app/api/events.py
+++ b/app/api/events.py
@@ -1,11 +1,14 @@
 from fastapi import APIRouter, status, Response, Depends
 
 from app.db.models import EventCreate, EventUpdate, EventPublic, EventWithAssignmentsPublic
-from app.utils.dependencies import SessionDep, ScheduleForEventsDep, EventDep, EventWithFullHierarchyDep, require_admin
+from app.utils.dependencies import SessionDep, ScheduleForEventsDep, EventDep, EventWithFullHierarchyDep, require_admin, verify_api_key, get_optional_bearer_token, get_db_session
 from app.services.builders import build_events_with_assignments_from_schedule, build_events_with_assignments_from_event
 from app.services.domain import update_object, create_event_with_default_assignment_slots, delete_object
 
-router = APIRouter(tags=["events"])
+router = APIRouter(
+    tags=["events"], 
+    dependencies=[Depends(verify_api_key), Depends(get_optional_bearer_token), Depends(get_db_session)]
+)
 
 @router.get("/schedules/{schedule_id}/events", response_model=list[EventWithAssignmentsPublic])
 def get_events_for_schedule(schedule: ScheduleForEventsDep):

--- a/app/api/proficiency_levels.py
+++ b/app/api/proficiency_levels.py
@@ -2,10 +2,14 @@ from fastapi import APIRouter, status, Response, Depends
 from sqlmodel import select
 
 from app.db.models import ProficiencyLevel, ProficiencyLevelCreate, ProficiencyLevelUpdate 
-from app.utils.dependencies import SessionDep, ProficiencyLevelDep, require_admin
+from app.utils.dependencies import SessionDep, ProficiencyLevelDep, require_admin, verify_api_key, get_optional_bearer_token, get_db_session
 from app.services.domain import create_object, update_object, delete_object
 
-router = APIRouter(prefix="/proficiency_levels", tags=["proficiency_levels"])
+router = APIRouter(
+    prefix="/proficiency_levels", 
+    tags=["proficiency_levels"], 
+    dependencies=[Depends(verify_api_key), Depends(get_optional_bearer_token), Depends(get_db_session)]
+)
 
 @router.get("", response_model=list[ProficiencyLevel])
 def get_all_proficiency_levels(session: SessionDep):

--- a/app/api/roles.py
+++ b/app/api/roles.py
@@ -2,10 +2,14 @@ from fastapi import APIRouter, status, Response, Depends
 from sqlmodel import select
 
 from app.db.models import Role, RoleCreate, RoleUpdate
-from app.utils.dependencies import SessionDep, RoleDep, require_admin
+from app.utils.dependencies import SessionDep, RoleDep, require_admin, verify_api_key, get_optional_bearer_token, get_db_session
 from app.services.domain import create_role_with_user_roles, update_object, delete_object
 
-router = APIRouter(prefix="/roles", tags=["roles"])
+router = APIRouter(
+    prefix="/roles", 
+    tags=["roles"], 
+    dependencies=[Depends(verify_api_key), Depends(get_optional_bearer_token), Depends(get_db_session)]
+)
 
 @router.get("", response_model=list[Role])
 def get_all_roles(session: SessionDep):

--- a/app/api/schedules.py
+++ b/app/api/schedules.py
@@ -2,10 +2,14 @@ from fastapi import APIRouter, status, Response, Depends
 from sqlmodel import select
 
 from app.db.models import Schedule, ScheduleCreate, ScheduleUpdate, ScheduleGridPublic
-from app.utils.dependencies import SessionDep, ScheduleDep, ScheduleWithEventsAndAssignmentsDep, require_admin
+from app.utils.dependencies import SessionDep, ScheduleDep, ScheduleWithEventsAndAssignmentsDep, require_admin, verify_api_key, get_optional_bearer_token, get_db_session
 from app.services.domain import update_object, get_schedule_grid_from_schedule, create_object, delete_object
 
-router = APIRouter(prefix="/schedules", tags=["schedules"])
+router = APIRouter(
+    prefix="/schedules", 
+    tags=["schedules"], 
+    dependencies=[Depends(verify_api_key), Depends(get_optional_bearer_token), Depends(get_db_session)]
+)
 
 @router.get("", response_model=list[Schedule])
 def get_all_schedules(session: SessionDep):

--- a/app/api/team_users.py
+++ b/app/api/team_users.py
@@ -1,10 +1,13 @@
 from fastapi import APIRouter, status, Response, Depends
 
 from app.db.models import TeamUser, TeamUserCreate, TeamUserUpdate, TeamUserPublic
-from app.utils.dependencies import SessionDep, TeamWithTeamUsersDep, TeamForTeamUsersDep, TeamUserDep, require_admin
+from app.utils.dependencies import SessionDep, TeamWithTeamUsersDep, TeamForTeamUsersDep, TeamUserDep, require_admin, verify_api_key, get_optional_bearer_token, get_db_session
 from app.services.domain import create_team_user_for_team, update_team_user, delete_object
 
-router = APIRouter(tags=["team_users"])
+router = APIRouter(
+    tags=["team_users"], 
+    dependencies=[Depends(verify_api_key), Depends(get_optional_bearer_token), Depends(get_db_session)]
+)
 
 @router.get("/teams/{team_id}/users", response_model=list[TeamUserPublic])
 def get_team_users_for_team(team: TeamWithTeamUsersDep):

--- a/app/api/teams.py
+++ b/app/api/teams.py
@@ -2,10 +2,14 @@ from fastapi import APIRouter, status, Response, Depends
 from sqlmodel import select
 
 from app.db.models import Team, TeamCreate, TeamUpdate
-from app.utils.dependencies import SessionDep, TeamDep, require_admin
+from app.utils.dependencies import SessionDep, TeamDep, require_admin, verify_api_key, get_optional_bearer_token, get_db_session
 from app.services.domain import create_object, update_object, delete_object
 
-router = APIRouter(prefix="/teams", tags=["teams"])
+router = APIRouter(
+    prefix="/teams", 
+    tags=["teams"], 
+    dependencies=[Depends(verify_api_key), Depends(get_optional_bearer_token), Depends(get_db_session)]
+)
 
 @router.get("", response_model=list[Team])
 def get_all_teams(session: SessionDep):

--- a/app/api/user_roles.py
+++ b/app/api/user_roles.py
@@ -1,10 +1,13 @@
 from fastapi import APIRouter, Depends
 
 from app.db.models import UserRoleUpdate, UserRolePublic
-from app.utils.dependencies import UserWithUserRolesDep, SessionDep, RoleWithUserRolesDep, UserRoleDep, require_admin
+from app.utils.dependencies import UserWithUserRolesDep, SessionDep, RoleWithUserRolesDep, UserRoleDep, require_admin, verify_api_key, get_optional_bearer_token, get_db_session
 from app.services.domain import update_user_role
 
-router = APIRouter(tags=["user_roles"])
+router = APIRouter(
+    tags=["user_roles"], 
+    dependencies=[Depends(verify_api_key), Depends(get_optional_bearer_token), Depends(get_db_session)]
+)
 
 # User roles are not created or deleted directly through an API endpoint - they are created when a user or role is created (same with delete)
 

--- a/app/api/user_unavailable_periods.py
+++ b/app/api/user_unavailable_periods.py
@@ -1,10 +1,13 @@
 from fastapi import APIRouter, status, Response, Depends
 
 from app.db.models import UserUnavailablePeriodCreate, UserUnavailablePeriodUpdate, UserUnavailablePeriodPublic
-from app.utils.dependencies import SessionDep, UserWithUserRolesForUnavailablePeriodsDep, UserUnavailablePeriodDep, require_admin
+from app.utils.dependencies import SessionDep, UserWithUserRolesForUnavailablePeriodsDep, UserUnavailablePeriodDep, require_admin, verify_api_key, get_optional_bearer_token, get_db_session
 from app.services.domain import create_user_unavailable_period, create_user_unavailable_periods_bulk, update_user_unavailable_period, delete_object
 
-router = APIRouter(tags=["user_unavailable_periods"])
+router = APIRouter(
+    tags=["user_unavailable_periods"], 
+    dependencies=[Depends(verify_api_key), Depends(get_optional_bearer_token), Depends(get_db_session)]
+)
 
 @router.post("/users/{user_id}/availability", 
     response_model=UserUnavailablePeriodPublic, 

--- a/app/api/users.py
+++ b/app/api/users.py
@@ -2,10 +2,14 @@ from fastapi import APIRouter, status, Response, Depends
 from sqlmodel import select
 
 from app.db.models import User, UserCreate, UserUpdate
-from app.utils.dependencies import SessionDep, UserDep, require_admin
+from app.utils.dependencies import SessionDep, UserDep, require_admin, verify_api_key, get_optional_bearer_token, get_db_session
 from app.services.domain import create_user_with_user_roles, update_object, delete_object
 
-router = APIRouter(prefix="/users", tags=["users"])
+router = APIRouter(
+    prefix="/users", 
+    tags=["users"], 
+    dependencies=[Depends(verify_api_key), Depends(get_optional_bearer_token), Depends(get_db_session)]
+)
 
 @router.get("", response_model=list[User])
 def get_all_users(session: SessionDep):

--- a/app/main.py
+++ b/app/main.py
@@ -43,8 +43,7 @@ app = FastAPI(
     description="API powering StewardHQ's scheduling, availability, and team management platform",
     version="1.0.0",
     openapi_tags=TAGS_METADATA,
-    lifespan=lifespan, 
-    dependencies=[Depends(verify_api_key), Depends(get_optional_bearer_token), Depends(get_db_session)],
+    lifespan=lifespan,
     swagger_ui_parameters={"persistAuthorization": True}
 )
 
@@ -62,7 +61,7 @@ if settings.cors_allowed_origins_list:
     )
 
 # Health check endpoint
-@app.get("/health", tags=["health"])
+@app.get("/health", tags=["health"], dependencies=[Depends(verify_api_key), Depends(get_optional_bearer_token), Depends(get_db_session)])
 def health(_: Request, session: SessionDep):
     """
     Health check endpoint that verifies application and database connectivity.


### PR DESCRIPTION
When a browser sends an OPTIONS request, because `verify_api_key`, `get_optional_bearer`, and `get_db_session` were registered at the top-level app, these dependencies would "fail" and we'd see a CORS error in the frontend. OPTIONS is a preflight check that does not need to go through these levels, so I moved them to the individual routers and explicitly exit these dependencies early if `request.method === "OPTIONS"` so that preflight checks will pass.